### PR TITLE
fix: move recursive renderChildren call after appendChild

### DIFF
--- a/src/react/render.js
+++ b/src/react/render.js
@@ -21,7 +21,6 @@ function renderChildren(children, domNode) {
       const dom = createDom(node.type, node.props);
 
       if (dom) {
-        renderChildren(node.props.children, dom);
         domNode.appendChild(dom);
 
         if (node.type.includes('-')) {
@@ -62,6 +61,8 @@ function renderChildren(children, domNode) {
             }
           };
         }
+
+        renderChildren(node.props.children, dom);
       }
     }
   }


### PR DESCRIPTION
Hi there @luwes, first of all very nice project it helped us a lot with SSR our web components within a Next.js app directory project. 🎉 

What I encountered is if we have web components which use the `<slot>`-element within another web components `<slot>`-element the react `renderChildren` function gets somehow stucked in an infinite loop. I was able to fix it by moving the recursive call of `renderChildren` after the `appendChild` call. 

Since our code is on our customers private repository i can't provide you with some reproduction code. 

Dummy codewise it looks something like this:
```TSX
// React JSX
return (<CustomDropdown text="Dropdown" hint="Hint" label="Label" ref={ref}>
    <CustomFlyout> // slot of custom-dropdown web component
      <CustomFlyoutItem item="item-1" label="Item 1" /> // slot of custom-flyout web component
      <CustomFlyoutItem item="item-2" label="Item 2" /> // slot of custom-flyout web component
      <CustomFlyoutItem item="item-3" label="Item 3" /> // slot of custom-flyout web component
      <CustomFlyoutItem item="item-4" label="Item 4" /> // slot of custom-flyout web component
    </CustomFlyout>
  </CustomDropdown>);
```