### PR TITLE
feat: add addEventListener and removeEventListener to globalThis shims

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -56,6 +56,8 @@ export function shim() {
     localStorage,
     ResizeObserver,
     CSSStyleDeclaration,
+    addEventListener: function addEventListener() {},
+    removeEventListener: function removeEventListener() {},
     getComputedStyle: function getComputedStyle() { return new CSSStyleDeclaration(); },
     requestAnimationFrame: function requestAnimationFrame() {},
     cancelAnimationFrame: function cancelAnimationFrame() {},


### PR DESCRIPTION
Hi there again @luwes 🙂 

beside the rendering problem i mentioned in my other pull request #3 we have the problem that our components register event listeners on the `window` which atm is not supported by your `globalThis` shim. 

Is there a reason you didn't add `addEventListener` and `removeEventListener` to `globalThis`? Otherwise would it be possible to add them see my PR? If you see any problem with this or don't want to add it let me know and we solve it on our side by extend the `globalThis` when rendering on server side.