### PR TITLE
feat: support component entry & w-trim attribute

### DIFF
--- a/crates/wesc/tests/fixtures/layouts/card.html
+++ b/crates/wesc/tests/fixtures/layouts/card.html
@@ -1,0 +1,7 @@
+<template>
+  Text before div
+  <div>
+    <slot>card default slot content</slot>
+  </div>
+  Text after div
+</template>

--- a/crates/wesc/tests/fixtures/layouts/expected.html
+++ b/crates/wesc/tests/fixtures/layouts/expected.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+<head></head>
+<body>
+  <w-card class="card">
+    Text before div
+    <div>
+      <p>Slotted &lt;p&gt; tag</p>
+    </div>
+    Text after div
+  </w-card>
+</body>
+</html>

--- a/crates/wesc/tests/fixtures/layouts/index.html
+++ b/crates/wesc/tests/fixtures/layouts/index.html
@@ -1,0 +1,10 @@
+<link rel="definition" name="w-root" href="./root.html">
+<link rel="definition" name="w-card" href="./card.html">
+
+<template>
+  <w-root w-trim>
+    <w-card class="card">
+      <p>Slotted &lt;p&gt; tag</p>
+    </w-card>
+  </w-root>
+</template>

--- a/crates/wesc/tests/fixtures/layouts/root.html
+++ b/crates/wesc/tests/fixtures/layouts/root.html
@@ -1,0 +1,9 @@
+<template>
+  <!doctype html>
+  <html>
+    <head></head>
+    <body>
+      <slot></slot>
+    </body>
+  </html>
+</template>

--- a/crates/wesc/tests/integration_test.rs
+++ b/crates/wesc/tests/integration_test.rs
@@ -45,6 +45,11 @@ fn real_world() {
     test_file("./tests/fixtures/real-world/index.html");
 }
 
+#[test]
+fn layouts() {
+    test_file("./tests/fixtures/layouts/index.html");
+}
+
 fn test_file(file_path: &str) {
     let mut output = Vec::new();
 


### PR DESCRIPTION
- support a component structure as the build entry point
- add the `w-trim` attribute that removes the component tag but keeps its content